### PR TITLE
Add support for npm distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+TextLayer.js
+node_modules/

--- a/README.md
+++ b/README.md
@@ -6,13 +6,38 @@ Framer.js module that simplifies the process of adding text to your prototypes.
 
 ## Installation
 
-1. Download the TextLayer.coffee file
-2. Create a framer project and drop TextLayer.coffee inside the /modules folder
-3. Add `TextLayer = require 'TextLayer'` at the top of your document (case-sensitive).
+Tested in [Framer Studio](http://framerjs.com) and [framer-cli](https://github.com/peteschaffner/framer-cli).
 
+1. Run `npm install framer-textlayer` in your prototype's directory (usually MyPrototype.framer/)
+2. Add a reference framer-textlayer by adding `textlayer = require("framer-textlayer")`. Where you do this depends on whether you're using Framer Studio or framer-cli
 
-More info about modules in Framer: [FramerJS Docs - Modules](http://framerjs.com/docs/#modules)
+## Framer Studio
 
+If you're using Framer Studio, you need to create an `npm.coffee` file in your modules folder, per [these instructions](http://framerjs.com/docs/#modules-npm-example).
+
+`MyPrototype.framer/modules/npm.coffee`
+
+```coffeescript
+# npm.coffee is a simple module wrapper
+exports.textlayer = require("framer-textlayer")
+# You could require more npm modules that you have installed on additional lines. For example, assuming you have backbone installed:
+#exports.backbone = require("backbone")
+```
+
+`MyPrototype.framer/app.coffee`
+
+```coffeescript
+npm = require("npm") # reference to your npm wrapper module
+TextLayer = npm.textlayer # now you have direct access to the framer-textlayer npm module
+```
+
+## framer-cli
+
+`index.coffee` (or index.js)
+
+```coffeescript
+pep = require("framer-textlayer")
+```
 
 ## Examples
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "framer-textlayer",
+  "version": "0.1.0",
+  "description": "Framer.js module that simplifies the process of adding text to your prototypes.",
+  "main": "TextLayer.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "coffee --compile TextLayer.coffee"
+  },
+  "author": "awt2542",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/WestonThayer/textLayer-for-Framer"
+  },
+  "bugs": {
+    "url": "https://github.com/WestonThayer/textLayer-for-Framer/issues"
+  },
+  "keywords": [
+    "framerjs",
+    "framer",
+    "TextLayer"
+  ],
+  "license": "MIT",
+  "devDependencies": {
+    "coffee-script": "^1.10.0"
+  },
+  "files": [
+    "TextLayer.js"
+  ]
+}


### PR DESCRIPTION
Hi Andreas! I've been working on adding npm-support to popular Framer.js modules. TextLayer happens to be a favorite :). This PR is all ready to go, you just need an [npm](http://npmjs.com) account to publish. Feel free to reach out to me directly at me@westonthayer.com. We're pushing npm as a superior package management system to copy/paste. I'll be writing on the FramerJs Facebook group and blogging more in the coming days, so no rush. This was just one of the first. If you want to play with how it works, replace "framer-textlayer" in the README.md instructions with "@westonthayer/framer-textlayer". This is a scoped npm package that I published to test it out.
 
Here's how you'd distribute:
1. Run `npm install`, this will install the coffee-script compiler in
   the node_modules folder
2. Run `npm run build`. This will create TextLayer.js, which is what
   gets shipped
3. Run `npm publish`
