### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,6 @@ Make sure the text layer in Sketch is inside a group. There can be no other laye
 
 **.convertToTextLayer()** - converts an imported layer to a TextLayer
 
-##Contact
+## Contact
 
 Twitter: [@andreaswah](http://twitter.com/andreaswah)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
